### PR TITLE
use absolute url for issues list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Introduction
 
-We are always looking for new contributions to the library – buildings, static aircraft, ground markings or anything else you would like to contribute. Also, check the GitHub [outstanding issues list](/OpenSceneryX/Library/issues) for tasks which you could help with.
+We are always looking for new contributions to the library – buildings, static aircraft, ground markings or anything else you would like to contribute. Also, check the GitHub [outstanding issues list](https://github.com/OpenSceneryX/Library/issues) for tasks which you could help with.
 
 # Copyright on Contributions
 


### PR DESCRIPTION
if you hit the current CONTRIBUTING.md via Github: https://github.com/OpenSceneryX/Library/blob/develop/CONTRIBUTING.md

The issues link doesn't work, it tries to go to https://github.com/OpenSceneryX/Library/blob/develop/OpenSceneryX/Library/issues

Using an absolute URL fixes this link.

Thanks for the library!